### PR TITLE
Fix main script name so require works

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "git",
      "url": "https://github.com/don/node-uri-beacon.git"
   },
-  "main": "uriBeacon.js",
+  "main": "uri-beacon.js",
   "scripts": {
     "pretest": "jshint *.js lib/. test/. examples/.",
      "test": "mocha -R spec test/*.js"


### PR DESCRIPTION
Currently `require('uri-beacon')` doesn't work because the main script attempts to run a file that doesn't exist. This PR fixes that.
