### PR TITLE
Substitute domain suffixes in the host part of the URI only

### DIFF
--- a/lib/uriEncoder.js
+++ b/lib/uriEncoder.js
@@ -7,6 +7,7 @@ var domains = [ ".com/", ".org/", ".edu/", ".net/", ".info/", ".biz/", ".gov/", 
 // shorten uris using substitution codes
 var encode = function (uri) {
 
+    var hostPort = uri.split('/')[0];
     var parts = [];
     var match;
 
@@ -32,14 +33,14 @@ var encode = function (uri) {
     match = null;
 
     for (i = 0; i < domains.length; i++) {
-        match = uri.match(domains[i]);
+        match = hostPort.match(domains[i]);
         if (match) {
             // save string before match
-            parts.push(uri.slice(0, match.index));
+            parts.push(hostPort.slice(0, match.index));
             // add substitution code
             parts.push(createBuffer(i));
             // save string after match
-            parts.push(uri.slice(match.index + domains[i].length));
+            parts.push(hostPort.slice(match.index + domains[i].length));
             break;
         }
     }


### PR DESCRIPTION
In other words: substitute domain suffixes **before** the first slash **only**.
Otherwise, URLs like `http://localhost/com` get erroneously substituted with `http://localhost/.com`...
