### PR TITLE
update to advertise as Eddystone-URL

### DIFF
--- a/lib/advertisement.js
+++ b/lib/advertisement.js
@@ -3,13 +3,13 @@ var encode = require('./uriEncoder').encode;
 var template = new Buffer(10); // maximum 31 bytes
 template[0] = 0x03; // Length
 template[1] = 0x03; // Parameter: Service List
-template[2] = 0xD8; // URI Beacon ID
+template[2] = 0xAA; // URI Beacon ID
 template[3] = 0xFE; // URI Beacon ID
 template[4] = 0x00; // Length
 template[5] = 0x16; // Service Data
-template[6] = 0xD8; // URI Beacon ID
+template[6] = 0xAA; // URI Beacon ID
 template[7] = 0xFE; // URI Beacon ID
-template[8] = 0x00; // Flags
+template[8] = 0x10; // Flags
 template[9] = 0xEB; // Power
 
 // txPowerLevel level is optional


### PR DESCRIPTION
Update to advertise as Eddystone beacon instead of phased out UriBeacon format
