### PR TITLE
Emitter

### DIFF
--- a/lib/beacon.js
+++ b/lib/beacon.js
@@ -1,6 +1,7 @@
 var os = require('os');
 
 var bleno = require('bleno');
+var EventEmitter = require('events').EventEmitter;
 
 var AdvertisementData = require('./util/advertisement-data');
 
@@ -8,6 +9,20 @@ var TICK_INTERVAL = 100; // ms
 var DEFAULT_TX_POWER_LEVEL = -21; // dBm
 
 function Beacon() {
+    EventEmitter.call(this);
+    reemit(bleno, this, [
+        'advertisingStartError',
+        'stateChange',
+        'servicesSetError',
+        'accept',
+        'mtuChange',
+        'disconnect',
+        'advertisingStart',
+        'advertisingStop',
+        'servicesSet',
+        'rssiUpdate'
+        ]);
+
     this._mainAdvertisementData = null;
     this._advertisementData = null;
     this._advertising = false;
@@ -21,6 +36,7 @@ function Beacon() {
 
     setInterval(this._tick.bind(this), TICK_INTERVAL);
 }
+util.inherits(Beacon, EventEmitter);
 
 Beacon.prototype.advertiseUid = function(namespaceId, instanceId, options) {
     this._parseOptions(options);

--- a/lib/beacon.js
+++ b/lib/beacon.js
@@ -1,6 +1,7 @@
 var os = require('os');
 
 var bleno = require('bleno');
+var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 
 var AdvertisementData = require('./util/advertisement-data');

--- a/lib/beacon.js
+++ b/lib/beacon.js
@@ -2,6 +2,7 @@ var os = require('os');
 
 var bleno = require('bleno');
 var util = require('util');
+var reemit = require('re-emitter');
 var EventEmitter = require('events').EventEmitter;
 
 var AdvertisementData = require('./util/advertisement-data');


### PR DESCRIPTION
It would be nice to emit, or internally listen to emitters and use callbacks for async support. For instance its currently impossible to know when you've successfully stopped advertising so you can start again. Also it would be nice to be notified of advertisingStartError and servicesSetError. 

@sandeepmistry offered to the solution just listen on the bleno singleton but it seems like these are in the domain of eddystone beacon and should be offered?

Anyway this should open it for discussion at least.
