### PR TITLE
Add callback support to advertise* and stop API's

### DIFF
--- a/lib/beacon.js
+++ b/lib/beacon.js
@@ -22,7 +22,7 @@ function Beacon() {
     setInterval(this._tick.bind(this), TICK_INTERVAL);
 }
 
-Beacon.prototype.advertiseUid = function(namespaceId, instanceId, options) {
+Beacon.prototype.advertiseUid = function(namespaceId, instanceId, options, callback) {
     this._parseOptions(options);
 
     this._advertisementData = AdvertisementData.makeUidBuffer(namespaceId, instanceId, this._txPowerLevel);
@@ -30,10 +30,10 @@ Beacon.prototype.advertiseUid = function(namespaceId, instanceId, options) {
 
     this._mainAdvertisementData = this._advertisementData;
 
-    this._advertiseWhenPoweredOn();
+    this._advertiseWhenPoweredOn(callback);
 };
 
-Beacon.prototype.advertiseUrl = function(url, options) {
+Beacon.prototype.advertiseUrl = function(url, options, callback) {
     this._parseOptions(options);
 
     this._advertisementData = AdvertisementData.makeUrlBuffer(url, this._txPowerLevel);
@@ -41,10 +41,10 @@ Beacon.prototype.advertiseUrl = function(url, options) {
 
     this._mainAdvertisementData = this._advertisementData;
 
-    this._advertiseWhenPoweredOn();
+    this._advertiseWhenPoweredOn(callback);
 };
 
-Beacon.prototype.advertiseTlm = function() {
+Beacon.prototype.advertiseTlm = function(callback) {
     this._advertisementData = AdvertisementData.makeTlmBuffer(this._batteryVoltage, this._temperature, this._advCnt, this._secCnt);
 
     if (this._tlmPeriod === 0) {
@@ -53,7 +53,7 @@ Beacon.prototype.advertiseTlm = function() {
     }
 
     this._removeFlagsIfOsX();
-    this._advertiseWhenPoweredOn();
+    this._advertiseWhenPoweredOn(callback);
 };
 
 Beacon.prototype.setBatteryVoltage = function(batteryVoltage) {
@@ -64,9 +64,9 @@ Beacon.prototype.setTemperature = function(temperature) {
     this._temperature = temperature;
 };
 
-Beacon.prototype.stop = function() {
+Beacon.prototype.stop = function(callback) {
     this._advertising = false;
-    bleno.stopAdvertising();
+    bleno.stopAdvertising(callback);
 };
 
 Beacon.prototype._parseOptions = function(options) {
@@ -107,11 +107,15 @@ Beacon.prototype._parseTlmOptions = function(options) {
     this._tlmCount = tlmCount;
 };
 
-Beacon.prototype._advertiseWhenPoweredOn = function() {
+Beacon.prototype._advertiseWhenPoweredOn = function(callback) {
     if (bleno.state === 'poweredOn') {
         this._advertise();
     } else {
         bleno.once('stateChange', this._advertiseWhenPoweredOn.bind(this));
+    }
+
+    if (typeof(callback) === 'function') {
+        bleno.once('advertisingStart', callback);
     }
 };
 


### PR DESCRIPTION
Alternative to #22, need to update read me later.

Example:

``` javascript
eddystoneBeacon.advertiseUid('00010203040506070809', 'aabbccddeeff', {}, function() {
  console.log('advertiseUid started');

  setTimeout(function() {
    eddystoneBeacon.stop(function() {
      console.log('stopped');
    });
  }, 10000);
});

```

@jacobrosenthal thoughts?
