### PR TITLE
Connectable example

### DIFF
--- a/examples/connectable/connectable.js
+++ b/examples/connectable/connectable.js
@@ -1,0 +1,28 @@
+var bleno = require('eddystone-beacon/node_modules/bleno'); // require('bleno');
+var eddystoneBeacon = require('eddystone-beacon'); // require('./../../index')
+
+var characteristic = new bleno.Characteristic({
+  uuid: 'E0D38F1C-56CA-4B75-9D44-3E4134F7CB0B',
+  properties: ['read'],
+  value: new Buffer('example')
+});
+
+var service = new bleno.PrimaryService({
+  uuid: 'E0D38F1C-56CA-4B75-9D44-3E4134F7CB0A',
+  characteristics: [
+    characteristic
+  ]
+})
+
+bleno.once('advertisingStart', function(err) {
+  if (err) {
+    throw err;
+  }
+
+  console.log('on -> advertisingStart')
+  bleno.setServices([
+    service
+  ]);
+});
+
+eddystoneBeacon.advertiseUrl('http://www.example.com');


### PR DESCRIPTION
As requested in #30 by @beaufortfrancois.

I was having issues on Linux (Raspberry Pi - Jessie) until I changed the require for bleno to: `require('eddystone-beacon/node_modules/bleno')`, based on http://stackoverflow.com/a/9736561/2020087 (it's not standard practice though).

@beaufortfrancois let us know if this or @don's suggestion in https://github.com/don/node-eddystone-beacon/issues/30#issuecomment-161074474 works for you, happy to add it as an example.
