### PR TITLE
Add a Fat Beacon support and an example

### DIFF
--- a/examples/fatBeacon/index.html
+++ b/examples/fatBeacon/index.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <title>Fat Beacon Demo</title>
+    <meta charset='UTF-8'>
+    <meta name='description' content='Fat Beacon Demo'/>
+  </head>
+  <body>
+    <h1>HelloWorld</h1>
+    This is a test 
+    <div>Adding more content to see if I can push it over the MTU value</div>
+    <div>Adding more content to see if I can push it over the MTU value</div>
+    <div>Adding more content to see if I can push it over the MTU value</div>
+  </body> 
+</html>

--- a/examples/fatBeacon/index.html
+++ b/examples/fatBeacon/index.html
@@ -6,9 +6,6 @@
   </head>
   <body>
     <h1>HelloWorld</h1>
-    This is a test 
-    <div>Adding more content to see if I can push it over the MTU value</div>
-    <div>Adding more content to see if I can push it over the MTU value</div>
-    <div>Adding more content to see if I can push it over the MTU value</div>
+    <svg xmlns="http://www.w3.org/2000/svg" width="171" height="202"><g fill="#3F82C4" fill-rule="evenodd"><path d="M141.2 85.3c0-31-25-56-56-56-30.7 0-55.8 25-55.8 56 0 17 7.8 32.5 20 42.8l10-10c-9.8-7.6-16-19.4-16-32.7 0-23.2 18.8-42 42-42 23 0 41.8 18.8 41.8 42 0 13.3-6.2 25-16 32.8l10 10c12.2-10.2 20-25.6 20-42.7"/><path d="M14 85.3C14 46 46 14 85.3 14s71.3 32 71.3 71.3c0 21.4-9.5 40.6-24.5 53.7l10 10c17.6-15.7 28.6-38.4 28.6-63.7 0-47-38.2-85.3-85.3-85.3C38.3 0 0 38.2 0 85.3c0 25.3 11 48 28.5 63.6l10-10C23.5 126 14 106.7 14 85.3"/><path d="M89.2 200.3c-2 2-5.5 2-7.6 0l-35.8-35.8c-2-2-2-5.5 0-7.6l35.8-36c2-2 5.5-2 7.6 0l35.8 36c2 2 2 5.4 0 7.5l-35.8 35.8z"/></g></svg>
   </body> 
 </html>

--- a/examples/fatBeacon/simple.js
+++ b/examples/fatBeacon/simple.js
@@ -4,13 +4,16 @@ var eddystoneBeacon = require('./../../index');
 
 var html = "<html>" + 
       "<head>" +
-        "<title>Fat Beacon Demo2</title>" +
+        "<title>Fat Beacon Demo</title>" +
         "<meta charset='UTF-8'>" + 
         "<meta name='description' content='Fat Beacon Demo'/>" + 
        "</head>" + 
        "<body>" +
         "<h1>HelloWorld</h1>" +
         "This is a test" + 
+        "<div>Adding more content to see if I can it over the MTU value</div>" + 
+        "<div>Adding more content to see if I can it over the MTU value</div>" + 
+        "<div>Adding more content to see if I can it over the MTU value</div>" + 
        "</body>" + 
       "</html>";
 

--- a/examples/fatBeacon/simple.js
+++ b/examples/fatBeacon/simple.js
@@ -4,12 +4,14 @@ var eddystoneBeacon = require('./../../index');
 
 var html = "<html>" + 
       "<head>" +
-       "<title>Fat Beacon Demo</title>" +
-       "<meta name='description' content='FatBeacon Demo'/>"
-      "</head>" + 
-      "<body>" +
-       "<h1>HelloWorld</h1>"
-      "</body>" + 
-       "</html>";
+        "<title>Fat Beacon Demo2</title>" +
+        "<meta charset='UTF-8'>" + 
+        "<meta name='description' content='Fat Beacon Demo'/>" + 
+       "</head>" + 
+       "<body>" +
+        "<h1>HelloWorld</h1>" +
+        "This is a test" + 
+       "</body>" + 
+      "</html>";
 
 eddystoneBeacon.advertiseFatBeacon('Fat Beacon Demo', {html: html});

--- a/examples/fatBeacon/simple.js
+++ b/examples/fatBeacon/simple.js
@@ -1,20 +1,12 @@
-// Simplest way to create a Eddystone-URL Beacon
+// Simplest way to create a Eddystone-FatBeacon
+
+// might want to include something like this https://www.npmjs.com/package/html-minify
 
 var eddystoneBeacon = require('./../../index');
+var fs = require('fs');
 
-var html = "<html>" + 
-      "<head>" +
-        "<title>Fat Beacon Demo</title>" +
-        "<meta charset='UTF-8'>" + 
-        "<meta name='description' content='Fat Beacon Demo'/>" + 
-       "</head>" + 
-       "<body>" +
-        "<h1>HelloWorld</h1>" +
-        "This is a test" + 
-        "<div>Adding more content to see if I can it over the MTU value</div>" + 
-        "<div>Adding more content to see if I can it over the MTU value</div>" + 
-        "<div>Adding more content to see if I can it over the MTU value</div>" + 
-       "</body>" + 
-      "</html>";
-
-eddystoneBeacon.advertiseFatBeacon('Fat Beacon Demo', {html: html});
+fs.readFile('index.html', function(err, data){
+  if (!err) {
+    eddystoneBeacon.advertiseFatBeacon('Fat Beacon Demo', {html: data});
+  }
+});

--- a/examples/fatBeacon/simple.js
+++ b/examples/fatBeacon/simple.js
@@ -1,0 +1,15 @@
+// Simplest way to create a Eddystone-URL Beacon
+
+var eddystoneBeacon = require('./../../index');
+
+var html = "<html>" + 
+      "<head>" +
+       "<title>Fat Beacon Demo</title>" +
+       "<meta name='description' content='FatBeacon Demo'/>"
+      "</head>" + 
+      "<body>" +
+       "<h1>HelloWorld</h1>"
+      "</body>" + 
+       "</html>";
+
+eddystoneBeacon.advertiseFatBeacon('Fat Beacon Demo', {html: html});

--- a/lib/HTMLCharacteristic.js
+++ b/lib/HTMLCharacteristic.js
@@ -16,13 +16,21 @@
 var bleno = require('bleno');
 var util = require('util');
 
+var currentMTU = 0;
+var queueOffset = 0;
 
 bleno.on('mtuChange', function(mtu) {
-  console.log('on -> mtuChange: ' + mtu);
+  //console.log('on -> mtuChange: ' + mtu);
+  currentMTU = mtu;
+});
+
+bleno.on('accept', function(){
+  queueOffset = 0;
 });
 
 function HTMLCharacteristic(html) {
   this._html = html;
+  this._buffer = new Buffer(this._html, 'utf8');
   bleno.Characteristic.call(this, {
     uuid: 'd1a517f0249946ca9ccc809bc1c966fa',
     properties: ['read'],
@@ -38,12 +46,16 @@ function HTMLCharacteristic(html) {
 util.inherits(HTMLCharacteristic,bleno.Characteristic);
 
 HTMLCharacteristic.prototype.onReadRequest = function(offset, callback) {
-  var buf = new Buffer(this._html, 'utf8');
-  if (offset < buf.length) {
-    var slice = buf.slice(offset);
+  //var buf = new Buffer(this._html, 'utf8');
+  if (queueOffset < this._buffer.length) {
+    var transfer = currentMTU - 5;
+    var end = queueOffset + transfer >= this._buffer.length ? this._buffer.length: queueOffset + transfer;
+    var slice = this._buffer.slice(queueOffset, end);
     callback(this.RESULT_SUCCESS, slice);
-  } else {
-    //problem
+    queueOffset = end;
+  } else if (queueOffset === this._buffer.length) {
+    callback(this.RESULT_SUCCESS, new Buffer());
+    queueOffset++;
   }
 
 }

--- a/lib/HTMLCharacteristic.js
+++ b/lib/HTMLCharacteristic.js
@@ -24,6 +24,7 @@ bleno.on('mtuChange', function(mtu) {
   currentMTU = mtu;
 });
 
+// mtu change comes during middle of read and we resets index mid read, what was this trying to do?
 bleno.on('accept', function(){
   queueOffset = 0;
 });

--- a/lib/HTMLCharacteristic.js
+++ b/lib/HTMLCharacteristic.js
@@ -1,0 +1,48 @@
+/**
+* Copyright 2016 IBM Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+var bleno = require('bleno');
+var util = require('util');
+
+
+function HTMLCharacteristic(html) {
+  this._html = html;
+  bleno.Characteristic.call(this, {
+    uuid: 'd1a517f0249946ca9ccc809bc1c966fa',
+    properties: ['read'],
+    descriptors: [
+      new bleno.Descriptor({
+        uuid: '2901',
+        value: 'HTML'
+      })
+    ]
+  });
+}
+
+util.inherits(HTMLCharacteristic,bleno.Characteristic);
+
+HTMLCharacteristic.prototype.onReadRequest = function(offset, callback) {
+  console.log("read request");
+  var buf = new Buffer(this._html, 'utf8');
+  if (offset < buf.length) {
+    var slice = buf.slice(offset);
+    callback(this.RESULT_SUCCESS, slice);
+  } else {
+    //problem
+  }
+
+}
+
+module.exports = HTMLCharacteristic;

--- a/lib/HTMLCharacteristic.js
+++ b/lib/HTMLCharacteristic.js
@@ -17,6 +17,10 @@ var bleno = require('bleno');
 var util = require('util');
 
 
+bleno.on('mtuChange', function(mtu) {
+  console.log('on -> mtuChange: ' + mtu);
+});
+
 function HTMLCharacteristic(html) {
   this._html = html;
   bleno.Characteristic.call(this, {
@@ -34,7 +38,6 @@ function HTMLCharacteristic(html) {
 util.inherits(HTMLCharacteristic,bleno.Characteristic);
 
 HTMLCharacteristic.prototype.onReadRequest = function(offset, callback) {
-  console.log("read request");
   var buf = new Buffer(this._html, 'utf8');
   if (offset < buf.length) {
     var slice = buf.slice(offset);

--- a/lib/HTMLCharacteristic.js
+++ b/lib/HTMLCharacteristic.js
@@ -16,20 +16,9 @@
 var bleno = require('bleno');
 var util = require('util');
 
-var currentMTU = 0;
-var queueOffset = 0;
-
-bleno.on('mtuChange', function(mtu) {
-  //console.log('on -> mtuChange: ' + mtu);
-  currentMTU = mtu;
-});
-
-// mtu change comes during middle of read and we resets index mid read, what was this trying to do?
-bleno.on('accept', function(){
-  queueOffset = 0;
-});
-
 function HTMLCharacteristic(html) {
+  this._currentMTU = 0;
+  this._queueOffset = 0;
   this._html = html;
   this._buffer = new Buffer(this._html, 'utf8');
   bleno.Characteristic.call(this, {
@@ -42,21 +31,29 @@ function HTMLCharacteristic(html) {
       })
     ]
   });
+
+  var self = this;
+  bleno.on('mtuChange', function(mtu) {
+    self._currentMTU = mtu;
+  });
+
+  bleno.on('disconnect', function(){
+    self._queueOffset = 0;
+  });
 }
 
 util.inherits(HTMLCharacteristic,bleno.Characteristic);
 
 HTMLCharacteristic.prototype.onReadRequest = function(offset, callback) {
-  //var buf = new Buffer(this._html, 'utf8');
-  if (queueOffset < this._buffer.length) {
-    var transfer = currentMTU - 5;
-    var end = queueOffset + transfer >= this._buffer.length ? this._buffer.length: queueOffset + transfer;
-    var slice = this._buffer.slice(queueOffset, end);
+  if (this._queueOffset < this._buffer.length) {
+    var transfer = this._currentMTU - 5;
+    var end = this._queueOffset + transfer >= this._buffer.length ? this._buffer.length: this._queueOffset + transfer;
+    var slice = this._buffer.slice(this._queueOffset, end);
     callback(this.RESULT_SUCCESS, slice);
-    queueOffset = end;
-  } else if (queueOffset === this._buffer.length) {
+    this._queueOffset = end;
+  } else if (this._queueOffset === this._buffer.length) {
     callback(this.RESULT_SUCCESS, new Buffer());
-    queueOffset++;
+    this._queueOffset++;
   }
 
 }

--- a/lib/HTMLCharacteristic.js
+++ b/lib/HTMLCharacteristic.js
@@ -32,14 +32,13 @@ function HTMLCharacteristic(html) {
     ]
   });
 
-  var self = this;
   bleno.on('mtuChange', function(mtu) {
-    self._currentMTU = mtu;
-  });
+    this._currentMTU = mtu;
+  }.bind(this));
 
   bleno.on('disconnect', function(){
-    self._queueOffset = 0;
-  });
+    this._queueOffset = 0;
+  }.bind(this));
 }
 
 util.inherits(HTMLCharacteristic,bleno.Characteristic);

--- a/lib/beacon.js
+++ b/lib/beacon.js
@@ -57,9 +57,14 @@ Beacon.prototype.advertiseFatBeacon = function(title, options) {
         uuid: 'ae5946d4e5874ba8b6a5a97cca6affd3',
         characteristics: [htmlCharacteristic]
     });
-    bleno.setServices([
-        fatBeaconService
-    ]);
+
+    var services = [fatBeaconService];
+
+    if (options.services) {
+        services = services.concat(options.services);
+    }
+
+    bleno.setServices(services);
 
     this._advertisementData = AdvertisementData.makeFatBeaconBuffer(title, this._txPowerLevel);
     this._removeFlagsIfOsX();

--- a/lib/beacon.js
+++ b/lib/beacon.js
@@ -64,7 +64,13 @@ Beacon.prototype.advertiseFatBeacon = function(title, options) {
         services = services.concat(options.services);
     }
 
-    bleno.setServices(services);
+    bleno.once('advertisingStart', function(err) {
+      if (err) {
+        throw err;
+      }
+
+      bleno.setServices(services);
+    });
 
     this._advertisementData = AdvertisementData.makeFatBeaconBuffer(title, this._txPowerLevel);
     this._removeFlagsIfOsX();

--- a/lib/beacon.js
+++ b/lib/beacon.js
@@ -4,6 +4,8 @@ var bleno = require('bleno');
 
 var AdvertisementData = require('./util/advertisement-data');
 
+var HTMLCharacteristic = require('./HTMLCharacteristic');
+
 var TICK_INTERVAL = 100; // ms
 var DEFAULT_TX_POWER_LEVEL = -21; // dBm
 
@@ -19,6 +21,7 @@ function Beacon() {
     this._temperature = -128;
     this._secCnt = 0;
     this._advCnt = 0;
+    this._html = null;
 
     setInterval(this._tick.bind(this), TICK_INTERVAL);
 }
@@ -38,6 +41,27 @@ Beacon.prototype.advertiseUrl = function(url, options) {
     this._parseOptions(options);
 
     this._advertisementData = AdvertisementData.makeUrlBuffer(url, this._txPowerLevel);
+    this._removeFlagsIfOsX();
+
+    this._mainAdvertisementData = this._advertisementData;
+
+    this._advertiseWhenPoweredOn();
+};
+
+Beacon.prototype.advertiseFatBeacon = function(title, options) {
+
+    this._parseOptions(options);
+
+    var htmlCharacteristic = new HTMLCharacteristic(this._html);
+    var fatBeaconService = new bleno.PrimaryService({
+        uuid: 'ae5946d4e5874ba8b6a5a97cca6affd3',
+        characteristics: [htmlCharacteristic]
+    });
+    bleno.setServices([
+        fatBeaconService
+    ]);
+
+    this._advertisementData = AdvertisementData.makeFatBeaconBuffer(title, this._txPowerLevel);
     this._removeFlagsIfOsX();
 
     this._mainAdvertisementData = this._advertisementData;
@@ -76,6 +100,13 @@ Beacon.prototype._parseOptions = function(options) {
     this._parseTxPowerLevelOption(options.txPowerLevel);
     this._parseTlmOptions(options);
     this._parseNameOption(options.name);
+    this._parseFatBeaconOption(options.html);
+};
+
+Beacon.prototype._parseFatBeaconOption = function(html) {
+    if (html) {
+        this._html = html;
+    }
 };
 
 Beacon.prototype._parseNameOption = function(name) {

--- a/lib/util/advertisement-data.js
+++ b/lib/util/advertisement-data.js
@@ -63,7 +63,7 @@ var makeFatBeaconBuffer = function (title, txPowerLevel) {
     var data = Buffer.concat([
         txPowerLevelData,
         new Buffer([0x0E]),
-        Buffer.from(title)
+        new Buffer(title)
     ]);
 
     return makeEddystoneBuffer(URL_FRAME_TYPE, data);

--- a/lib/util/advertisement-data.js
+++ b/lib/util/advertisement-data.js
@@ -55,11 +55,6 @@ var makeUrlBuffer = function (url, txPowerLevel) {
 var makeFatBeaconBuffer = function (title, txPowerLevel) {
     var txPowerLevelData = makeTxPowerLevelBuffer(txPowerLevel);
 
-    // if (encodedUrl.length > MAX_URL_LENGTH) {
-    //     throw new Error('Encoded URL must be less than ' + MAX_URL_LENGTH +
-    //                     ' bytes. It is currently ' + data.length + ' bytes.');
-    // }
-
     var data = Buffer.concat([
         txPowerLevelData,
         new Buffer([0x0E]),

--- a/lib/util/advertisement-data.js
+++ b/lib/util/advertisement-data.js
@@ -52,6 +52,24 @@ var makeUrlBuffer = function (url, txPowerLevel) {
     return makeEddystoneBuffer(URL_FRAME_TYPE, data);
 };
 
+var makeFatBeaconBuffer = function (title, txPowerLevel) {
+    var txPowerLevelData = makeTxPowerLevelBuffer(txPowerLevel);
+
+    // if (encodedUrl.length > MAX_URL_LENGTH) {
+    //     throw new Error('Encoded URL must be less than ' + MAX_URL_LENGTH +
+    //                     ' bytes. It is currently ' + data.length + ' bytes.');
+    // }
+
+    var data = Buffer.concat([
+        txPowerLevelData,
+        new Buffer([0x0E]),
+        Buffer.from(title)
+    ]);
+
+    return makeEddystoneBuffer(URL_FRAME_TYPE, data);
+};
+
+
 var makeTlmBuffer = function (vBatt, temp, advCnt, secCnt) {
     var tlmData = new Buffer(13);
 
@@ -99,5 +117,6 @@ var hexStringIdToBuffer = function(hexStringId) {
 module.exports = {
     makeUidBuffer: makeUidBuffer,
     makeUrlBuffer: makeUrlBuffer,
-    makeTlmBuffer: makeTlmBuffer
+    makeTlmBuffer: makeTlmBuffer,
+    makeFatBeaconBuffer: makeFatBeaconBuffer
 };


### PR DESCRIPTION
Based on the discussion in https://github.com/google/physical-web/issues/814 this should add Fat Beacon support to node-eddystone-beacon 
