### PR TITLE
use https for examples

### DIFF
--- a/examples/connectable/connectable.js
+++ b/examples/connectable/connectable.js
@@ -29,4 +29,4 @@ bleno.once('advertisingStart', function(err) {
   ]);
 });
 
-eddystoneBeacon.advertiseUrl('http://www.example.com');
+eddystoneBeacon.advertiseUrl('https://www.example.com');

--- a/examples/url/name.js
+++ b/examples/url/name.js
@@ -1,3 +1,3 @@
 var eddystoneBeacon = require('./../../index');
 
-eddystoneBeacon.advertiseUrl('http://www.eff.org', { name: 'Beacon' });
+eddystoneBeacon.advertiseUrl('https://www.eff.org', { name: 'Beacon' });

--- a/examples/url/power-level.js
+++ b/examples/url/power-level.js
@@ -2,4 +2,4 @@ var eddystoneBeacon = require('./../../index');
 
 // txPowerLevel can be set in options hash
 // should be between -100 and 20 dBm
-eddystoneBeacon.advertiseUrl('http://www.eff.org', { txPowerLevel: -31 });
+eddystoneBeacon.advertiseUrl('https://www.eff.org', { txPowerLevel: -31 });

--- a/examples/url/simple.js
+++ b/examples/url/simple.js
@@ -2,4 +2,4 @@
 
 var eddystoneBeacon = require('./../../index');
 
-eddystoneBeacon.advertiseUrl('http://www.google.com');
+eddystoneBeacon.advertiseUrl('https://www.google.com');


### PR DESCRIPTION
Only https URLs will show up in Google Chrome and Android Nearby.
